### PR TITLE
Use betaflight timings for dshot

### DIFF
--- a/src/pio/bidir_dshot_x1.pio
+++ b/src/pio/bidir_dshot_x1.pio
@@ -9,9 +9,9 @@ pull block
 ; write DShot packet
 out null, 16; throw away the left 16 bits
 write_one_bit:
-set pins, 0 [14]
-out pins, 1 [14]
-set pins, 1 [8]
+set pins, 0 [13]
+out pins, 1 [13]
+set pins, 1 [10]
 jmp !osre write_one_bit
 
 ; one bit takes 32 PIO cycles, so after 16 PIO cycles we begin to count it as a bit. After 32 more cycles the second bit etc.

--- a/src/pio/bidir_dshot_x1.pio.h
+++ b/src/pio/bidir_dshot_x1.pio.h
@@ -21,9 +21,9 @@ static const uint16_t bidir_dshot_x1_program_instructions[] = {
 	0xe081, //  1: set    pindirs, 1
 	0x80a0, //  2: pull   block
 	0x6070, //  3: out    null, 16
-	0xee00, //  4: set    pins, 0                [14]
-	0x6e01, //  5: out    pins, 1                [14]
-	0xe801, //  6: set    pins, 1                [8]
+	0xed00, //  4: set    pins, 0                [13]
+	0x6d01, //  5: out    pins, 1                [13]
+	0xea01, //  6: set    pins, 1                [10]
 	0x00e4, //  7: jmp    !osre, 4
 	0xe034, //  8: set    x, 20
 	0xa0eb, //  9: mov    osr, !null

--- a/src/pio/dshotx4.pio
+++ b/src/pio/dshotx4.pio
@@ -1,8 +1,11 @@
 .program dshotx4
 
+; writes 8 bits per word/pull
+; since each packet is 16 bits, we count on the CPU to send 2 packets in a row
+
 .wrap_target
 pull ifempty block
-set pins, 0b1111 [14]
-out pins, 4 [14]
-set pins, 0b0000 [8]
+set pins, 0b1111 [13]
+out pins, 4 [13]
+set pins, 0b0000 [10]
 .wrap

--- a/src/pio/dshotx4.pio.h
+++ b/src/pio/dshotx4.pio.h
@@ -18,9 +18,9 @@
 static const uint16_t dshotx4_program_instructions[] = {
 	//     .wrap_target
 	0x80e0, //  0: pull   ifempty block
-	0xee0f, //  1: set    pins, 15               [14]
-	0x6e04, //  2: out    pins, 4                [14]
-	0xe800, //  3: set    pins, 0                [8]
+	0xed0f, //  1: set    pins, 15               [13]
+	0x6d04, //  2: out    pins, 4                [13]
+	0xea00, //  3: set    pins, 0                [10]
 	//     .wrap
 };
 


### PR DESCRIPTION
https://github.com/betaflight/betaflight/blob/f336df392e3d89a84e34dce2c2b3f597ae0d2cdd/src/platform/common/stm32/dshot_dpwm.h and dshot_dpwm.c

The timings for DShot seem to vary from ESC firmware to ESC firmware, and from spec to spec. This PR adjusts the code to use BF's timings instead of the ones found in most specs, since Bluejay and some others aren't compatible with them