### PR TITLE
Weak linking for Arduino

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(Pico_Bidir_DShot VERSION 1.0.1 LANGUAGES CXX)
+project(Pico_Bidir_DShot VERSION 1.0.2 LANGUAGES CXX)
 
 add_library(Pico_Bidir_DShot STATIC)
 

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
 	"name": "Pico_Bidir_DShot",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"keywords": "dshot",
 	"build": {
 		"libLDFMode": "off"

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Pico_Bidir_DShot
-version=1.0.1
+version=1.0.2
 author=Bastian2001
 maintainer=Bastian2001
 sentence=Bidirectional DShot library for RP2040/RP2350 (Raspberry Pi Pico Series), using the PIO hardware.

--- a/src/PIO_DShot.h
+++ b/src/PIO_DShot.h
@@ -1,6 +1,10 @@
 #ifndef PIO_DSHOT_H
 #define PIO_DSHOT_H
 
+#ifndef NUM_PIOS
+#error [pico-bidir-dshot]: The board you are trying to compile for does not have the PIO hardware. This library is only supported on RP2040/RP235x based devices. If you believe this to be an error, please file an issue. In this case, you can disable this error and try to compile anyway by going to the PIO_DShot.h file (exact location should be mentioned just before this error) and comment out this error.
+#endif
+
 #include "bidir_dshot_x1.h"
 #include "dshot_x4.h"
 

--- a/src/PIO_DShot.h
+++ b/src/PIO_DShot.h
@@ -2,7 +2,7 @@
 #define PIO_DSHOT_H
 
 #ifndef NUM_PIOS
-#error [pico-bidir-dshot]: The board you are trying to compile for does not have the PIO hardware. This library is only supported on RP2040/RP235x based devices. If you believe this to be an error, please file an issue. In this case, you can disable this error and try to compile anyway by going to the PIO_DShot.h file (exact location should be mentioned just before this error) and comment out this error.
+#error [Pico_Bidir_DShot]: The board you are trying to compile for does not have the PIO hardware. This library is only supported on RP2040/RP235x based devices. If you believe this message to be an error, please file an issue on GitHub. In this case, you can disable this message and try to compile anyway by going to the PIO_DShot.h file (exact location should be mentioned just before this error) and comment out this line.
 #endif
 
 #include "bidir_dshot_x1.h"

--- a/src/dshot_common.cpp
+++ b/src/dshot_common.cpp
@@ -15,3 +15,10 @@ void pioToPioStr(PIO pio, char str[32]) {
 	}
 }
 #endif
+
+// in case _gpio_init does not exist, define it weakly
+extern "C" void _gpio_init(uint gpio) __attribute__((weak));
+
+extern "C" __attribute__((weak)) void gpio_init(uint gpio) {
+	_gpio_init(gpio);
+}

--- a/src/dshot_common.h
+++ b/src/dshot_common.h
@@ -1,7 +1,15 @@
 #include "dshot_config.h"
+#include "hardware/gpio.h"
 #include "hardware/pio.h"
 
 #define DBG defined(DSHOT_DEBUG)
+
+// Pico-SDK: doesn't have ARDUINO defined
+// Earle Phil Hower's core: has ARDUINO defined, but also a version
+// Arduino standard core: needs special treatment, only has ARDUINO defined
+#define CAN_USE_SDK_FUNCTIONS ((defined(ARDUINO) && defined(ARDUINO_PICO_MAJOR)) || !defined(ARDUINO))
+
+void gpio_init(uint gpio);
 
 #if DBG
 #include "Arduino.h"


### PR DESCRIPTION
This PR adds a weak linkage for the gpio_init function, which Arduino Mbed OS hides away as _gpio_init because of "conflicting names", despite the fact that there wouldn't be a conflict because of the different call signatures. Either way, this weak linkage is discarded in case of using Earle Philhower's core, or when using the Pico SDK and only sticks when using the standard Arduino core (Mbed OS).

I considered using a check for some defines, but that could break quite easily and a dynamic linker adjustment felt a little more robust.